### PR TITLE
Get Away Mode method added to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This library is initially focused on supporting a Phyn integration for Home Assi
 - Device state
 - Water consumption
 - Shutoff valve control
+- Get and set away mode
 
 ## Acknowledgements
 

--- a/aiophyn/device.py
+++ b/aiophyn/device.py
@@ -88,6 +88,16 @@ class Device:
             "post",
             f"{API_BASE}/devices/{device_id}/sov/Close",
         )
+    
+    async def get_away_mode(self, device_id: str) -> dict:
+        """Return away mode status of a device.
+
+        :param device_id: Unique identifier for the device
+        :type device_id: ``str``
+        :rtype: ``dict``
+        """
+        return await self._request("get", f"{API_BASE}/preferences/device/{device_id}/leak_sensitivity_away_mode")
+
 
     async def enable_away_mode(self, device_id: str) -> None:
         """Enable the device's away mode.

--- a/aiophyn/utils/device_dump.py
+++ b/aiophyn/utils/device_dump.py
@@ -12,6 +12,7 @@ _LOGGER = logging.getLogger()
 
 async def device_dump(username: str, password: str) -> None:
     device_states = []
+    away_mode_states = []
     async with ClientSession() as session:
         try:
             api = await async_get_api(username, password, session=session)
@@ -20,9 +21,15 @@ async def device_dump(username: str, password: str) -> None:
                 for device_id in home.get("device_ids", []):
                     device_state = await api.device.get_state(device_id)
                     device_states.append(device_state)
+
+                    away_mode = await api.device.get_away_mode(device_id)
+                    away_mode_states.append(away_mode)
             print("\n" * 3)
             pprint(device_states)
             print("\n" * 3)
+            pprint(away_mode_states)
+            print("\n" * 3)
+
         except PhynError as err:
             _LOGGER.error("There was an error: %s", err)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aiophyn"
-version = "2023.01.0"
+version = "2023.08.0"
 description = "An asynchronous library for Phyn Smart Water devices"
 authors = ["MizterB <5458030+MizterB@users.noreply.github.com>"]
 license = "MIT"


### PR DESCRIPTION
- Added new method to aiophyn API to get away mode status
- Added away mode details in the device dump sample

Away Mode data is returned from the Phyn API as part of the device preferences. It is returned as a dictionary in the following structure: 

`{
    'device_id': '1245341412',
    'name': 'leak_sensitivity_away_mode',
    'updated_ts': 1693192720990,
    'value': 'false'
}`

this closes #3 